### PR TITLE
Prevent KeyError and UnboundLocalError when no gpx & activity type not recognized

### DIFF
--- a/strava_to_fittrackee/s2f.py
+++ b/strava_to_fittrackee/s2f.py
@@ -439,6 +439,7 @@ class StravaConnector:
                 f"Strava activity {activity_id} had no GPS data; cannot download GPX!"
             )
             get_streams = False
+            distance = 0
 
         if get_streams:
             logger.debug(f"Getting latitude and longitude for activity {activity_id}")
@@ -1061,7 +1062,10 @@ def sync_strava_with_fittrackee():
                 act = strava.create_activity_from_strava(a, get_streams=True)
                 if act.lat == [None] and act.long == [None]:
                     # we don't have any GPS data, so do manual activity
-                    fittrackee.upload_no_gpx(act)
+                    if act.type in fittrackee.sport_id_map:
+                        fittrackee.upload_no_gpx(act)
+                    else:
+                        logger.warning(f"Activity type {act.type} not recognized in FitTrackee, skipping!")
                 else:
                     temp_file = tempdir.name + f'/{act.activity_dict["id"]}.gpx'
                     logger.debug(f"Writing Strava activity gpx to {temp_file}")


### PR DESCRIPTION
Added some checks to skip invalid activities (maybe that should be an option though?)

Those were the errors I was getting:
<details>
  <summary>KeyError</summary>

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/bonswouar/git/strava-to-fittrackee/strava_to_fittrackee/s2f.py", line 1121, in <module>
    sync_strava_with_fittrackee()
  File "/home/bonswouar/git/strava-to-fittrackee/strava_to_fittrackee/s2f.py", line 1064, in sync_strava_with_fittrackee
    fittrackee.upload_no_gpx(act)
  File "/home/bonswouar/git/strava-to-fittrackee/strava_to_fittrackee/s2f.py", line 851, in upload_no_gpx
    "sport_id": self.sport_id_map[activity_type],
                ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'Swim'
```
</details>
<details>
  <summary>UnboundLocalError</summary>

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/bonswouar/git/strava-to-fittrackee/strava_to_fittrackee/s2f.py", line 1124, in <module>
    sync_strava_with_fittrackee()
  File "/home/bonswouar/git/strava-to-fittrackee/strava_to_fittrackee/s2f.py", line 1061, in sync_strava_with_fittrackee
    act = strava.create_activity_from_strava(a, get_streams=True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bonswouar/git/strava-to-fittrackee/strava_to_fittrackee/s2f.py", line 491, in create_activity_from_strava
    velocity=velocity,
             ^^^^^^^^
UnboundLocalError: cannot access local variable 'distance' where it is not associated with a value
```
</details>

Resolves #12 and #11 
